### PR TITLE
Refactor About text to a separate component

### DIFF
--- a/Components/About.js
+++ b/Components/About.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import CaptionedNumber from './CaptionedNumber';
+import DropcapText from './DropcapText';
 import Section from './Section';
 import SectionTitle from './SectionTitle';
 import SubSectionTitle from './SubSectionTitle';
-import Text from './Text';
 
 import '../css/Components/About';
 
@@ -17,12 +17,12 @@ const About = () => (
       <div className="About-content">
         <SubSectionTitle>Empowering People</SubSectionTitle>
         <div className="About-text">
-          <Text>
+          <DropcapText>
             Mirror Conf is a conference designed to empower designers and front-end developers
             who have a thirst for knowledge and want to broaden their horizons.
             It aims to create the perfect set to blur the differences between these two worlds
             and point towards a more collaborative future.
-          </Text>
+          </DropcapText>
         </div>
         <div className="About-info">
           <div className="About-attendancePhoto" />

--- a/Components/DropcapText.js
+++ b/Components/DropcapText.js
@@ -1,0 +1,19 @@
+import React, { PropTypes } from 'react';
+
+import Text from './Text';
+
+import '../css/Components/DropcapText';
+
+const DropcapText = ({ children }) => (
+  <div className="DropcapText">
+    <Text>
+      {children}
+    </Text>
+  </div>
+);
+
+DropcapText.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default DropcapText;

--- a/css/Components/About.scss
+++ b/css/Components/About.scss
@@ -5,9 +5,6 @@
 $About-content-max-width: 982px;
 
 $About-text-max-width: 534px;
-$About-text-first-letter-font-size: 57px;
-$About-text-first-letter-line-height: 52px;
-$About-text-first-letter-spacing-right: 6px;
 
 $About-currentEdition-max-width: 378px;
 
@@ -48,14 +45,6 @@ $About-photo-mobile-gradient: to right,
 .About-text {
   max-width: $About-text-max-width;
   margin: $Spacing-xSmall 0 $Spacing-base;
-
-  &::first-letter {
-    float: left;
-    padding-right: $About-text-first-letter-spacing-right;
-
-    font-size: $About-text-first-letter-font-size;
-    line-height: $About-text-first-letter-line-height;
-  }
 }
 
 .About-info {

--- a/css/Components/DropcapText.scss
+++ b/css/Components/DropcapText.scss
@@ -1,0 +1,13 @@
+$DropcapText-letter-font-size: 57px;
+$DropcapText-letter-line-height: 52px;
+$DropcapText-letter-spacing-right: 6px;
+
+.DropcapText {
+  &::first-letter {
+    float: left;
+    padding-right: $DropcapText-letter-spacing-right;
+
+    font-size: $DropcapText-letter-font-size;
+    line-height: $DropcapText-letter-line-height;
+  }
+}


### PR DESCRIPTION
I'd like some feedback on whether or not the `DropcapText` component should make use of `Text` or not.