### PR TITLE
Adds a node version check to the deploy script

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,3 +1,13 @@
 #!/bin/sh
 
+LOCAL_NODE_VERSION=$(node -v)
+EXPECTED_NODE_VERSION=$(cat .nvmrc)
+
+if [ "$LOCAL_NODE_VERSION" != "v$EXPECTED_NODE_VERSION" ];
+then
+  echo "[ERR]: Node version is different from the target version." >&2
+  echo "Try running \`nvm use\`" >&2
+  exit 1
+fi
+
 yarn install && yarn run build && s3_website push


### PR DESCRIPTION
I recently f*cked up the style in the production page... again...

This was because I forgot to run `nvm use` and ended up running the deploy script with my system node version, which is incompatible with the installed modules.

This PR adds a check to that, making it @frmendes proof.