### PR TITLE
Increases clickable area of burger button

### DIFF
--- a/Components/Burger.js
+++ b/Components/Burger.js
@@ -28,10 +28,12 @@ export default class Burger extends Component {
 
     return (
       <button onClick={onClick} className={className} >
-        <div className="Burger-line" />
-        <div className="Burger-line" />
-        <div className="Burger-line" />
-        {this.renderLabel()}
+        <div className="Burger-content">
+          <div className="Burger-line" />
+          <div className="Burger-line" />
+          <div className="Burger-line" />
+          {this.renderLabel()}
+        </div>
       </button>
     );
   }

--- a/css/Components/Burger.scss
+++ b/css/Components/Burger.scss
@@ -3,6 +3,7 @@
 @import "../Theme/Breakpoint";
 @import "../Theme/Mixins";
 
+$Burger-outer-size: 48px;
 $Burger-line-height: 2px;
 $Burger-label-font-size: 8px;
 $Burger-label-line-height: 8px;
@@ -11,6 +12,8 @@ $Burger-label-font-weight: bold;
 $Burger-label-letter-spacing: 0.5px;
 
 .Burger {
+  width: $Burger-outer-size;
+  height: $Burger-outer-size;
   display: block;
 
   background: none;
@@ -21,6 +24,10 @@ $Burger-label-letter-spacing: 0.5px;
   @include Breakpoint-desktopOnly {
     display: none;
   }
+}
+
+.Burger-content {
+  display: inline-block;
 }
 
 .Burger-line {


### PR DESCRIPTION
[Google's guidelines for mobile
development](https://developers.google.com/speed/docs/insights/SizeTapTargetsAppropriately) recommend 48px as the minimum size of a main clickable area for mobile

This PR increases the clickable area for the burger button without
changing the content itself