### PR TITLE
Moves video background to a Youtube embedded version

### DIFF
--- a/Components/Hero.js
+++ b/Components/Hero.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import classNames from 'classnames';
+import Youtube from 'react-youtube';
 
 import '../css/Components/Hero';
 import '../css/Components/Grid';
@@ -8,81 +10,104 @@ import TextTitle from './TextTitle';
 import Mirrored from './Mirrored';
 import SocialLinks from './SocialLinks';
 
-import HeroVideo from '../pages/hero.mp4';
-import HeroPoster from '../pages/hero-cover.jpg';
 import HeroFallback from '../pages/hero.jpg';
 import PlayIcon from '../images/play.svg';
 
-const Hero = () => (
-  <section className="Hero">
-    <div className="Hero-background">
-      <Mirrored id="video" hide>
-        <video
-          loop
-          muted
-          autoPlay
-          playsInline
-          preload="auto"
-          type="video/mp4"
-          poster={HeroPoster}
-          className="Hero-video"
-          ref={video => video.play}
-        >
-          <source src={HeroVideo} />
-          <source src={HeroFallback} />
-        </video>
-      </Mirrored>
-      <Mirrored id="video" hide>
-        <div className="Hero-backgroundOverlay" />
-      </Mirrored>
-    </div>
-
-    <Section>
-      <div className="Hero-foreground">
-        <div className="Hero-content Grid Grid--1offset">
-          <div className="Hero-title">
-            <h1 className="Hero-headline">Mirror Conf 2017</h1>
-            <h2 className="Hero-uvp">
-              For designers and front-end developers.
-            </h2>
-            <h3 className="Hero-date">
-              October 10 — 13, 2017<br />
-              Braga, Portugal
-            </h3>
-
-            <h4 className="Hero-fullDate">
-              Oct. 10 & 11 — workshops,<br />
-              12 & 13 — main conference
-            </h4>
-          </div>
-
-          <div className="Hero-actions">
-            <Mirrored id="button" hover>
-              <a href="https://www.youtube.com/watch?v=JWa0PMXN7ZE" className="Hero-playButton" target="blank">
-                <img src={PlayIcon} alt="Play icon" className="Hero-playButtonImage" />
-                <div className="Hero-playButtonLabel">
-                  <TextTitle>
-                    1st edition<br />
-                    best of
-                  </TextTitle>
-                </div>
-              </a>
-            </Mirrored>
-          </div>
-        </div>
-
-        <div className="Hero-footer">
-          <SocialLinks />
-          <div className="Hero-footerSpace" />
-          <TextTitle alternate>Follow us</TextTitle>
-        </div>
-      </div>
-    </Section>
-  </section>
-);
-
-Hero.componentDidMount = () => {
-
+const YoutubeVideoId = "B7bqAsxee4I"
+const youtubeOpts = {
+  playerVars: {
+    autoplay: 1,
+    loop: 1,
+    controls: 0,
+    playlist: YoutubeVideoId,
+  },
 };
 
-export default Hero;
+
+export default class Hero extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { playing: false };
+  }
+
+  componentDidMount() {
+  }
+
+  onYoutubePlay = () => {
+    this.setState({ playing: true });
+  }
+
+  classes() {
+    return classNames({
+      Hero: true,
+      'is-video-playing': this.state.playing,
+    });
+  }
+
+  render() {
+    return (
+      <section className={this.classes()}>
+        <div className="Hero-background">
+          <Mirrored id="video-fallback" hide>
+            <img className="Hero-videoFallback" src={HeroFallback} alt="MirrorConf 2016 video placeholder" />
+          </Mirrored>
+          <Mirrored id="video" disable>
+            <div className="Hero-videoWrapper">
+              <Youtube
+                className="Hero-video"
+                videoId={YoutubeVideoId}
+                onPlay={this.onYoutubePlay}
+                opts={youtubeOpts}
+              />
+            </div>
+          </Mirrored>
+          <Mirrored id="overlay" hide>
+            <div className="Hero-backgroundOverlay" />
+          </Mirrored>
+        </div>
+
+        <Section>
+          <div className="Hero-foreground">
+            <div className="Hero-content Grid Grid--1offset">
+              <div className="Hero-title">
+                <h1 className="Hero-headline">Mirror Conf 2017</h1>
+                <h2 className="Hero-uvp">
+                  For designers and front-end developers.
+                </h2>
+                <h3 className="Hero-date">
+                  October 10 — 13, 2017<br />
+                  Braga, Portugal
+                </h3>
+
+                <h4 className="Hero-fullDate">
+                  Oct. 10 & 11 — workshops,<br />
+                  12 & 13 — main conference
+                </h4>
+              </div>
+
+              <div className="Hero-actions">
+                <Mirrored id="button" hover>
+                  <a href="https://www.youtube.com/watch?v=JWa0PMXN7ZE" className="Hero-playButton" target="blank">
+                    <img src={PlayIcon} alt="Play icon" className="Hero-playButtonImage" />
+                    <div className="Hero-playButtonLabel">
+                      <TextTitle>
+                        1st edition<br />
+                        best of
+                      </TextTitle>
+                    </div>
+                  </a>
+                </Mirrored>
+              </div>
+            </div>
+
+            <div className="Hero-footer">
+              <SocialLinks />
+              <div className="Hero-footerSpace" />
+              <TextTitle alternate>Follow us</TextTitle>
+            </div>
+          </div>
+        </Section>
+      </section>
+    );
+  }
+}

--- a/Components/Mirrored.js
+++ b/Components/Mirrored.js
@@ -1,10 +1,11 @@
 import React from 'react';
 
-const Mirrored = ({ children, id, hover, hide }) => {
+const Mirrored = ({ children, id, hover, hide, disable }) => {
   const finalProps = {
     'data-mirror-id': id,
     'data-mirror-hide': hide,
     'data-mirror-hover': hover,
+    'data-mirror-disable': disable,
   };
 
   return React.cloneElement(children, finalProps);

--- a/css/Components/Hero.scss
+++ b/css/Components/Hero.scss
@@ -54,16 +54,26 @@ $Hero-backgroundOverlay-color: rgba(8, 19, 64, 0.7);
   @include variablesSupported {
     background: linear-gradient(to bottom, $Hero-backgroundOverlay-color 20%, var(--color-background) 100%);
   }
+}
 
+.Hero-videoFallback,
+.Hero-video {
+  position: absolute;
+  min-width: 1100px;
+  width: 100%;
+  height: 120%;
+  left: 50%;
+  top: 50%;
+
+  transform: translateX(-50%) translateY(-50%);
 }
 
 .Hero-video {
-  height: 100%;
-
-  @include Breakpoint-desktopOnly {
-    width: 100%;
-    height: auto;
-  };
+  opacity: 0;
+  transition: all 0.3s linear;
+}
+.Hero.is-video-playing .Hero-video {
+  opacity: 1;
 }
 
 .Hero-foreground {

--- a/css/Components/Mirror.scss
+++ b/css/Components/Mirror.scss
@@ -81,6 +81,10 @@ $Mirror-reflection-transform: 129px;
   visibility: hidden;
 }
 
+.Mirror-reflection [data-mirror-disable] {
+  display: none;
+}
+
 .Mirror-container {
   display: none;
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-headroom": "^2.1.2",
     "react-helmet": "^4.0.0",
     "react-slick": "^0.14.6",
+    "react-youtube": "^7.3.0",
     "scss-lint": "^0.0.0",
     "slick-carousel": "^1.6.0",
     "toml-js": "0.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4195,6 +4195,10 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+
 loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@^0.2.3, loader-utils@^0.2.5, loader-utils@^0.2.6, loader-utils@^0.2.7, loader-utils@~0.2.2, loader-utils@~0.2.5:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.16.tgz#f08632066ed8282835dff88dfb52704765adee6d"
@@ -4293,7 +4297,7 @@ lodash.isempty@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
-lodash.isequal@^4.0.0:
+lodash.isequal@^4.0.0, lodash.isequal@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
@@ -6110,6 +6114,13 @@ react-transform-hmr@^1.0.3:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
+react-youtube@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/react-youtube/-/react-youtube-7.3.0.tgz#eb1228866f48124ceb7f9825e7d4b562294584ef"
+  dependencies:
+    lodash.isequal "^4.4.0"
+    youtube-player "^4.0.1"
+
 react@^15.4.1, react@^15.4.2:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
@@ -6583,6 +6594,10 @@ sigmund@~1.0.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sister@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sister/-/sister-3.0.0.tgz#88eb57047cb283da1e070b1a7cae8212f3bcb2db"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -7638,3 +7653,12 @@ yauzl@^2.2.1:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
+
+youtube-player@^4.0.1:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-4.2.3.tgz#00248b7b012b2ae06177c77da8d893a6d01ca92c"
+  dependencies:
+    babel-runtime "^6.22.0"
+    load-script "^1.0.0"
+    lodash "^4.3.0"
+    sister "^3.0.0"


### PR DESCRIPTION
Due to bandwidth pricing, we're moving the video file (which is by far
the most consuming resource on Clouflare) to Youtube

An existing package was used to embed the video, with callbacks for when
the playback is started (after loading), so that we can show
a placeholder image beforehand