### PR TITLE
Improves performance by refactoring the way we use the Mirror component

### DIFF
--- a/Components/About.js
+++ b/Components/About.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 import CaptionedNumber from './CaptionedNumber';
 import DropcapText from './DropcapText';
-import Mirrored from './Mirrored';
 import Section from './Section';
 import SectionTitle from './SectionTitle';
 import SubSectionTitle from './SubSectionTitle';
@@ -27,9 +26,7 @@ const About = () => (
         </div>
         <div className="About-info">
           <div className="About-attendancePhoto" />
-          <Mirrored hide>
-            <div className="About-venuePhoto" />
-          </Mirrored>
+          <div className="About-venuePhoto" />
 
           <div className="About-currentEdition">
             <div className="About-currentTitle">

--- a/Components/Footer.js
+++ b/Components/Footer.js
@@ -4,7 +4,6 @@ import '../css/Components/Footer';
 import '../css/Components/Grid';
 
 import Link from './Link';
-import Mirrored from './Mirrored';
 import SubSectionTitle from './SubSectionTitle';
 import TextTitle from './TextTitle';
 import SocialLinks from './SocialLinks';
@@ -78,11 +77,9 @@ const Footer = () => (
             <TextTitle>MirrorConf is powered by</TextTitle>
           </div>
 
-          <Mirrored id="subvisual-logo" hide>
-            <a href="https://subvisual.co" rel="noopener noreferrer" target="_blank">
-              <img alt="Subvisual logo" src={SubvisualLogo} />
-            </a>
-          </Mirrored>
+          <a href="https://subvisual.co" rel="noopener noreferrer" target="_blank">
+            <img alt="Subvisual logo" src={SubvisualLogo} />
+          </a>
         </div>
       </div>
     </div>

--- a/Components/Hero.js
+++ b/Components/Hero.js
@@ -7,7 +7,7 @@ import '../css/Components/Grid';
 
 import Section from './Section';
 import TextTitle from './TextTitle';
-import Mirrored from './Mirrored';
+import Mirror from './Mirror';
 import SocialLinks from './SocialLinks';
 
 import HeroFallback from '../pages/hero.jpg';
@@ -46,49 +46,43 @@ export default class Hero extends React.Component {
     return (
       <section className={this.classes()}>
         <div className="Hero-background">
-          <Mirrored id="video-fallback" hide>
-            <img
-              className="Hero-videoFallback"
-              src={HeroFallback}
-              alt="MirrorConf 2016 video placeholder"
+          <img
+            className="Hero-videoFallback"
+            src={HeroFallback}
+            alt="MirrorConf 2016 video placeholder"
+          />
+          <div className="Hero-videoWrapper">
+            <Youtube
+              className="Hero-video"
+              videoId={YoutubeVideoId}
+              onPlay={this.onYoutubePlay}
+              opts={youtubeOpts}
             />
-          </Mirrored>
-          <Mirrored id="video" disable>
-            <div className="Hero-videoWrapper">
-              <Youtube
-                className="Hero-video"
-                videoId={YoutubeVideoId}
-                onPlay={this.onYoutubePlay}
-                opts={youtubeOpts}
-              />
-            </div>
-          </Mirrored>
-          <Mirrored id="overlay" hide>
-            <div className="Hero-backgroundOverlay" />
-          </Mirrored>
+          </div>
+          <div className="Hero-backgroundOverlay" />
         </div>
 
         <Section>
           <div className="Hero-foreground">
-            <div className="Hero-content Grid Grid--1offset">
-              <div className="Hero-title">
-                <h1 className="Hero-headline">Mirror Conf 2017</h1>
-                <h2 className="Hero-uvp">
-                  For designers and front-end developers.
-                </h2>
-                <h3 className="Hero-date">
-                  October 10 — 13, 2017<br />
-                  Braga, Portugal
-                </h3>
+            <Mirror>
+              <div className="Hero-content Grid Grid--1offset">
+                <div className="Hero-title">
+                  <h1 className="Hero-headline">Mirror Conf 2017</h1>
+                  <h2 className="Hero-uvp">
+                    For designers and front-end developers.
+                  </h2>
+                  <h3 className="Hero-date">
+                    October 10 — 13, 2017<br />
+                    Braga, Portugal
+                  </h3>
 
-                <h4 className="Hero-fullDate">
-                  Oct. 10 & 11 — workshops,<br />
-                  12 & 13 — main conference
-                </h4>
-              </div>
+                  <h4 className="Hero-fullDate">
+                    Oct. 10 & 11 — workshops,<br />
+                    12 & 13 — main conference
+                  </h4>
+                </div>
 
-              <div className="Hero-actions">
-                <Mirrored id="button" hover>
+                <div className="Hero-actions">
                   <a
                     href="https://www.youtube.com/watch?v=JWa0PMXN7ZE"
                     className="Hero-playButton"
@@ -106,9 +100,9 @@ export default class Hero extends React.Component {
                       </TextTitle>
                     </div>
                   </a>
-                </Mirrored>
+                </div>
               </div>
-            </div>
+            </Mirror>
 
             <div className="Hero-footer">
               <SocialLinks />

--- a/Components/Mirror.js
+++ b/Components/Mirror.js
@@ -7,11 +7,8 @@ const Mirror = ({ children }) => (
     <div className="Mirror-original">
       {children}
     </div>
-    <div className="Mirror-container">
-      <div className="Mirror-cut" />
-      <div className="Mirror-reflection">
-        {children}
-      </div>
+    <div className="Mirror-reflection">
+      {children}
     </div>
   </div>
 );

--- a/Components/MouseAnimator.js
+++ b/Components/MouseAnimator.js
@@ -5,15 +5,11 @@ import _ from 'lodash';
 export default class MouseAnimator {
   hook = () => {
     const layout = document.getElementsByClassName('Layout')[0];
-    const reflection = document.getElementsByClassName('Mirror-reflection')[0];
 
     const callback = (event) => {
       const mouseXRatio = event.clientX / window.innerWidth;
-      const mouseYRatio = event.clientY / window.innerHeight;
 
       layout.style.setProperty('--color-background', this.currentColor(mouseXRatio));
-      reflection.style.setProperty('--mirror-rotation-y', this.currentXRotation(mouseXRatio));
-      reflection.style.setProperty('--mirror-rotation-x', this.currentYRotation(mouseYRatio));
     };
 
     layout.addEventListener('mousemove', _.throttle(callback, 50));
@@ -29,12 +25,6 @@ export default class MouseAnimator {
 
   currentXRotation(ratio) {
     const degrees = this.lerp(-0.2, 0.2, ratio);
-
-    return `${degrees}deg`;
-  }
-
-  currentYRotation(ratio) {
-    const degrees = this.lerp(-0.02, 0.02, ratio);
 
     return `${degrees}deg`;
   }

--- a/Components/Moving.js
+++ b/Components/Moving.js
@@ -10,7 +10,6 @@ import SectionTitle from '../Components/SectionTitle';
 import TextHighlight from '../Components/TextHighlight';
 import NumberedBlock from '../Components/NumberedBlock';
 import SubSectionTitle from '../Components/SubSectionTitle';
-import Mirrored from '../Components/Mirrored';
 
 const Moving = () => (
   <div className="Moving">
@@ -55,16 +54,14 @@ const Moving = () => (
             </div>
           </div>
         </div>
-        <Mirrored hide>
-          <div className="Moving-imageWrapper">
-            <div className="Grid Grid--1offset">
-              <div className="Grid-4column" />
-              <div className="Grid-5column">
-                <div className="Moving-portoImage" />
-              </div>
+        <div className="Moving-imageWrapper">
+          <div className="Grid Grid--1offset">
+            <div className="Grid-4column" />
+            <div className="Grid-5column">
+              <div className="Moving-portoImage" />
             </div>
           </div>
-        </Mirrored>
+        </div>
       </div>
 
       <div className="Moving-section">
@@ -86,15 +83,13 @@ const Moving = () => (
             </div>
           </div>
         </div>
-        <Mirrored hide>
-          <div className="Moving-imageWrapper">
-            <div className="Grid Grid--1offset">
-              <div className="Grid-5column">
-                <div className="Moving-lisbonImage" />
-              </div>
+        <div className="Moving-imageWrapper">
+          <div className="Grid Grid--1offset">
+            <div className="Grid-5column">
+              <div className="Moving-lisbonImage" />
             </div>
           </div>
-        </Mirrored>
+        </div>
       </div>
     </Section>
   </div>

--- a/Components/Navbar.js
+++ b/Components/Navbar.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import Burger from './Burger';
 import Section from './Section';
-import Mirrored from './Mirrored';
 
 import Links from '../data/links';
 import '../css/Components/Navbar';
@@ -11,24 +10,22 @@ const renderLink = (link, index) => <span key={index} className="Navbar-link">{l
 
 const Navbar = ({ overlayOpen, toggleOverlayMenu }) => (
   <Section>
-    <Mirrored id="navbar" hide>
-      <div className="Navbar">
-        <a href="/">
-          <img src={MirrorLogo} alt="Mirror Logo" className="Navbar-logo" />
-        </a>
+    <div className="Navbar">
+      <a href="/">
+        <img src={MirrorLogo} alt="Mirror Logo" className="Navbar-logo" />
+      </a>
 
-        <div className="Navbar-links">
-          {Links.map(renderLink)}
-        </div>
-
-        <Burger
-          openLabel="Menu"
-          closeLabel="Close"
-          isOpen={overlayOpen}
-          onClick={toggleOverlayMenu}
-        />
+      <div className="Navbar-links">
+        {Links.map(renderLink)}
       </div>
-    </Mirrored>
+
+      <Burger
+        openLabel="Menu"
+        closeLabel="Close"
+        isOpen={overlayOpen}
+        onClick={toggleOverlayMenu}
+      />
+    </div>
   </Section>
 );
 

--- a/Components/Sponsors.js
+++ b/Components/Sponsors.js
@@ -7,7 +7,6 @@ import Text from './Text';
 import Link from './Link';
 import Button from './Button';
 import Section from './Section';
-import Mirrored from './Mirrored';
 import SectionTitle from './SectionTitle';
 import SubSectionTitle from './SubSectionTitle';
 import SponsorsData from '../data/sponsors';
@@ -48,35 +47,33 @@ const renderLevel = (data) => {
 };
 
 const Sponsors = () => (
-  <Mirrored hide>
-    <div className="Sponsors">
-      <Section>
-        <div className="Grid">
-          <div className="Grid-10column">
-            <div className="Sponsors-wrapper">
-              <div className="Sponsors-title">
-                <SectionTitle alternate>Sponsors</SectionTitle>
+  <div className="Sponsors">
+    <Section>
+      <div className="Grid">
+        <div className="Grid-10column">
+          <div className="Sponsors-wrapper">
+            <div className="Sponsors-title">
+              <SectionTitle alternate>Sponsors</SectionTitle>
+            </div>
+            <div className="Grid Grid--1offset">
+              <div className="Sponsors-levelsTitle">
+                <Text alternative>A warm thank you to our amazing sponsors.</Text>
               </div>
-              <div className="Grid Grid--1offset">
-                <div className="Sponsors-levelsTitle">
-                  <Text alternative>A warm thank you to our amazing sponsors.</Text>
-                </div>
-                { SponsorsData.map(renderLevel) }
-              </div>
-              <SubSectionTitle alternate>
-                Want to help us make the best conference?
-              </SubSectionTitle>
-              <div className="Sponsors-actions">
-                <Link noHover href="/sponsoring.pdf" target="_blank">
-                  <Button alternative>Sponsor us</Button>
-                </Link>
-              </div>
+              { SponsorsData.map(renderLevel) }
+            </div>
+            <SubSectionTitle alternate>
+              Want to help us make the best conference?
+            </SubSectionTitle>
+            <div className="Sponsors-actions">
+              <Link noHover href="/sponsoring.pdf" target="_blank">
+                <Button alternative>Sponsor us</Button>
+              </Link>
             </div>
           </div>
         </div>
-      </Section>
-    </div>
-  </Mirrored>
+      </div>
+    </Section>
+  </div>
 );
 
 export default Sponsors;

--- a/Components/WhiteBox.js
+++ b/Components/WhiteBox.js
@@ -2,19 +2,14 @@ import React, { PropTypes } from 'react';
 
 import '../css/Components/WhiteBox';
 
-import Mirrored from './Mirrored';
-
-const WhiteBox = ({ children, id }) => (
-  <Mirrored id={id} hide>
-    <div className="WhiteBox">
-      {children}
-    </div>
-  </Mirrored>
+const WhiteBox = ({ children }) => (
+  <div className="WhiteBox">
+    {children}
+  </div>
 );
 
 WhiteBox.propTypes = {
   children: PropTypes.node.isRequired,
-  id: PropTypes.string.isRequired,
 };
 
 export default WhiteBox;

--- a/css/Components/Layout.scss
+++ b/css/Components/Layout.scss
@@ -3,7 +3,10 @@
 @import "../Theme/Breakpoint";
 @import "../Theme/Browsers";
 
+$Layout-cut-max-width: 946px;
+
 .Layout {
+  position: relative;
   width: 100%;
   max-width: 100%;
 
@@ -28,4 +31,21 @@
   height: 100%;
 
   overflow: hidden;
+}
+
+.Layout-cut {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+
+  width: 100%;
+  height: 100%;
+  max-width: $Layout-cut-max-width;
+
+  background: linear-gradient(
+    to bottom, rgba($Color-white, 0) 0%, rgba($Color-white, 0.05) 70%
+  );
+
+  z-index: 1;
 }

--- a/css/Components/Mirror.scss
+++ b/css/Components/Mirror.scss
@@ -1,11 +1,4 @@
-@import "../Theme/Breakpoint";
-@import "../Theme/Browsers";
-@import "../Theme/Color";
 @import "../Theme/Global";
-@import "../Theme/Spacing";
-
-$Mirror-reflection-max-width: 946px;
-$Mirror-reflection-transform: 129px;
 
 .Mirror {
   position: relative;
@@ -18,40 +11,6 @@ $Mirror-reflection-transform: 129px;
 
 .Mirror-original {
   position: relative; //hack to make this allways on top
-}
-
-.Mirror-container {
-  position: absolute;
-  top: 0;
-  left: 50%;
-
-  width: 100%;
-  height: 100%;
-
-  overflow: hidden;
-
-  pointer-events: none;
-
-  perspective: 300px;
-  transform: translateX(-50%);
-
-  @include Breakpoint-mobileOnly {
-    display: none;
-  };
-}
-
-.Mirror-cut {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  transform: translateX(-50%);
-
-  width: 100%;
-  height: 100%;
-  max-width: $Mirror-reflection-max-width;
-  background: linear-gradient(
-    to bottom, rgba($Color-white, 0) 0%, rgba($Color-white, 0.05) 70%
-  );
 }
 
 .Mirror-reflection {
@@ -68,28 +27,17 @@ $Mirror-reflection-transform: 129px;
   transform: scaleX(-1) translateX(50%);
 
   filter: opacity(0.3) blur(7px);
-
-  @include variablesSupported {
-    transform: scaleX(-1) translateX(50%) rotateX(var(--mirror-rotation-x)) rotateY(var(--mirror-rotation-y));
-
-    --mirror-rotation-x: 0deg;
-    --mirror-rotation-y: 0deg;
-  }
 }
 
 .Mirror-reflection [data-mirror-hide] {
   visibility: hidden;
 }
 
-.Mirror-reflection [data-mirror-disable] {
+.Mirror-reflection [data-mirror-disable],
+.Mirror-reflection img,
+.Mirror-reflection [class*="Photo"],
+.Mirror-reflection [class="Speaker"],
+.Mirror-reflection [class="MoreToCome"],
+.Mirror-reflection .Workshop {
   display: none;
 }
-
-.Mirror-container {
-  display: none;
-
-  @include mirrorSupported {
-    display: block;
-  }
-}
-

--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -8,7 +8,6 @@ import '../css/Components/Layout';
 import Links from '../data/links';
 import Link from '../Components/Link';
 import Navbar from '../Components/Navbar';
-import Mirror from '../Components/Mirror';
 import OverlayMenu from '../Components/OverlayMenu';
 
 import MouseAnimator from '../Components/MouseAnimator';
@@ -50,18 +49,17 @@ export default class Template extends Component {
           <Link href="mailto:hello@mirrorconf.com">hello@mirrorconf.com</Link>
         </OverlayMenu>
 
-        <Mirror>
-          <nav className="Layout-navbar">
-            <Navbar
-              overlayOpen={overlayOpen}
-              toggleOverlayMenu={this.toggleOverlayMenu}
-            />
-          </nav>
+        <div className="Layout-cut" />
+        <nav className="Layout-navbar">
+          <Navbar
+            overlayOpen={overlayOpen}
+            toggleOverlayMenu={this.toggleOverlayMenu}
+          />
+        </nav>
 
-          <div className="Layout-content">
-            {children}
-          </div>
-        </Mirror>
+        <div className="Layout-content">
+          {children}
+        </div>
       </div>
     );
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,6 +7,7 @@ import Footer from '../Components/Footer';
 import Speakers from '../Components/Speakers';
 import Workshops from '../Components/Workshops';
 import Sponsors from '../Components/Sponsors';
+import Mirror from '../Components/Mirror';
 
 import '../css/Components/Index';
 
@@ -14,14 +15,20 @@ const Index = () => (
   <div className="Index">
     <Hero />
     <div className="Index-section">
-      <About />
+      <Mirror>
+        <About />
+      </Mirror>
       <Feedback />
     </div>
     <div className="Index-section">
-      <Speakers />
+      <Mirror>
+        <Speakers />
+      </Mirror>
     </div>
     <div className="Index-section">
-      <Workshops />
+      <Mirror>
+        <Workshops />
+      </Mirror>
     </div>
     <div className="Index-section">
       <Sponsors />

--- a/pages/location.js
+++ b/pages/location.js
@@ -8,6 +8,7 @@ import Moving from '../Components/Moving';
 import Sleeping from '../Components/Sleeping';
 // import Eating from '../Components/Eating';
 import Footer from '../Components/Footer';
+import Mirror from '../Components/Mirror';
 
 const tabs = [
   { id: 1, label: 'Moving', component: <Moving /> },
@@ -17,7 +18,9 @@ const tabs = [
 
 const LocationPage = () => (
   <div className="LocationPage">
-    <Venue />
+    <Mirror>
+      <Venue />
+    </Mirror>
     <div className="LocationPage-mainSection">
       <Tabs tabs={tabs} />
       <div className="LocationPage-cta" />


### PR DESCRIPTION
# TL;DR

1. We now apply the `Mirror` component to individual sections instead of
   around the entire page
2. Parallax effect of the mirror is now removed
3. Performance is better. Perhaps not by much, because the blur is still
   present, but this should already help.

# Long Version

In the previous version we were rendering the `Mirror` around the entire
page, and then cherry-picking elements to hide, for performance or
visual reasons.

Most of the hidden mirror components would need `visibility: hidden`
 instead of `display: none`, to preserve height. So they end up being
 rendered anyway, which still hurts performance, especially for images

Now, a new approach is used, where the global mirror is removed, and
instead added to specific places where we actually want it to show up.

These places are mostly title and text components. Since mirrors are
applied per section, we can now freely hide images with `display: none`,
as long as they're at the end of their container, which is the case for
all sections so far.

One drawback of this approach is that I had to remove the parallax
effect when moving the mouse. This drawback is another performance improvement in itself, so I still consider this a victory.