### PR TITLE
Fix sponsor spacing in intermediate screen sizes

### DIFF
--- a/css/Components/Sponsors.scss
+++ b/css/Components/Sponsors.scss
@@ -68,11 +68,11 @@
 }
 
 .Sponsors-levelLogo:not(:last-child) {
-  margin-bottom: $Spacing-xSmall;
+  margin-right: $Spacing-small;
+  margin-bottom: $Spacing-small;
 
-  @include Breakpoint-desktopOnly {
-    margin-right: $Spacing-small;
-    margin-bottom: $Spacing-small;
+  @include Breakpoint-mobileOnly {
+    margin-bottom: $Spacing-xSmall;
   }
 }
 


### PR DESCRIPTION
Why:

<img width="522" alt="screen shot 2017-07-21 at 15 47 39" src="https://user-images.githubusercontent.com/4325027/28468844-19a6ef40-6e2c-11e7-9e99-8e8191e7c14c.png">

This change addresses the need by:

* Reversing the order of the properties and the media query to include intermediate sizes.

<img width="639" alt="screen shot 2017-07-21 at 15 48 10" src="https://user-images.githubusercontent.com/4325027/28468858-2aa150ce-6e2c-11e7-9fac-6a441a233223.png">
