### PR TITLE
Fixes location images height issue

### DIFF
--- a/Components/Moving.js
+++ b/Components/Moving.js
@@ -27,9 +27,11 @@ const Moving = () => (
               <SubSectionTitle>Porto Airport (OPO)</SubSectionTitle>
             </div>
             <div className="Moving-description">
-              <Text>
-                The closest airport is in Porto (OPO), from where you can either:
-              </Text>
+              <div className="Moving-listTitle">
+                <Text>
+                  The closest airport is in Porto (OPO), from where you can either:
+                </Text>
+              </div>
               <br />
               <div className="Moving-descriptionNumberedBlock">
                 <NumberedBlock number="1.">

--- a/Components/Moving.js
+++ b/Components/Moving.js
@@ -31,28 +31,30 @@ const Moving = () => (
                 The closest airport is in Porto (OPO), from where you can either:
               </Text>
               <br />
-              <NumberedBlock number="1.">
-                <Text>
-                  Catch a direct bus with a service called
-                  {' '}
-                  <Link target="_blank" href="https://getbus.eu/en/" noHover>
-                    <TextHighlight>GetBus</TextHighlight>
-                  </Link>
-                  ;
-                </Text>
-              </NumberedBlock>
-              <br />
-              <NumberedBlock number="2.">
-                <Text>
-                  Catch a
-                  {' '}
-                  <Link target="_blank" href="https://www.cp.pt/passageiros/pt/consultar-horarios/estacoes/porto-campanha" noHover>
-                    <TextHighlight>train at Porto Campanhã</TextHighlight>
-                  </Link>
-                  {' '}
-                  (~ 1 hour trip).
-                </Text>
-              </NumberedBlock>
+              <div className="Moving-descriptionNumberedBlock">
+                <NumberedBlock number="1.">
+                  <Text>
+                    Catch a direct bus with a service called
+                    {' '}
+                    <Link target="_blank" href="https://getbus.eu/en/" noHover>
+                      <TextHighlight>GetBus</TextHighlight>
+                    </Link>
+                    ;
+                  </Text>
+                </NumberedBlock>
+                <br />
+                <NumberedBlock number="2.">
+                  <Text>
+                    Catch a
+                    {' '}
+                    <Link target="_blank" href="https://www.cp.pt/passageiros/pt/consultar-horarios/estacoes/porto-campanha" noHover>
+                      <TextHighlight>train at Porto Campanhã</TextHighlight>
+                    </Link>
+                    {' '}
+                    (~ 1 hour trip).
+                  </Text>
+                </NumberedBlock>
+              </div>
             </div>
           </div>
         </div>
@@ -60,7 +62,9 @@ const Moving = () => (
           <div className="Grid Grid--1offset">
             <div className="Grid-4column" />
             <div className="Grid-5column">
-              <div className="Moving-portoImage" />
+              <div className="Moving-portoImageWrapper">
+                <div className="Moving-portoImage" />
+              </div>
             </div>
           </div>
         </div>
@@ -88,7 +92,9 @@ const Moving = () => (
         <div className="Moving-imageWrapper">
           <div className="Grid Grid--1offset">
             <div className="Grid-5column">
-              <div className="Moving-lisbonImage" />
+              <div className="Moving-lisbonImageWrapper">
+                <div className="Moving-lisbonImage" />
+              </div>
             </div>
           </div>
         </div>

--- a/css/Components/Moving.scss
+++ b/css/Components/Moving.scss
@@ -31,10 +31,7 @@ $Moving-gradient-start-color: rgba(13, 29, 97, 0.4);
 
 .Moving-section {
   position: relative;
-
-  @include Breakpoint-desktopOnly {
-    min-height: $Moving-image-height;
-  }
+  min-height: $Moving-image-height;
 }
 
 .Moving-section:not(:last-child) {
@@ -53,13 +50,6 @@ $Moving-gradient-start-color: rgba(13, 29, 97, 0.4);
 .Moving-lisbonImageWrapper {
   position: relative;
   height: $Moving-image-height;
-
-  @include Breakpoint-mobileOnly {
-    height: 0;
-    $image-ratio: $Moving-image-height / 294px;
-    padding-bottom: calc(100% * #{$image-ratio});
-    max-width: 500px;
-  }
 
   @include Breakpoint-desktopOnly {
     margin-top: 0;
@@ -98,16 +88,23 @@ $Moving-gradient-start-color: rgba(13, 29, 97, 0.4);
 
 .Moving-imageWrapper {
   width: 100%;
-  @include Breakpoint-desktopOnly {
-    position: absolute;
+  position: absolute;
+  top: 0;
 
-    top: 0;
+  @include Breakpoint-mobileOnly {
+    position: initial;
   }
 }
 
 .Moving-description {
   position: relative;
   z-index: $Moving-z-index-foreground;
+}
+
+.Moving-listTitle {
+  @include Breakpoint-tabletAndBelow {
+    margin-left: $Spacing-xSmall;
+  }
 }
 
 .Moving-descriptionNumberedBlock {

--- a/css/Components/Moving.scss
+++ b/css/Components/Moving.scss
@@ -41,41 +41,58 @@ $Moving-gradient-start-color: rgba(13, 29, 97, 0.4);
   margin-bottom: $Spacing-base;
 }
 
-.Moving-portoImage,
-.Moving-lisbonImage {
-  position: relative;
+.Moving-portoImageWrapper {
+  margin-top: -$Spacing-small;
+}
 
-  width: 100%;
+.Moving-lisbonImageWrapper {
+  margin-top: -$Spacing-xSmall;
+}
+
+.Moving-portoImageWrapper,
+.Moving-lisbonImageWrapper {
+  position: relative;
   height: $Moving-image-height;
 
-  margin-bottom: -$Spacing-small;
-
-  transform: translateY(-$Spacing-small);
-
-  z-index: $Moving-z-index-background;
+  @include Breakpoint-mobileOnly {
+    height: 0;
+    $image-ratio: $Moving-image-height / 294px;
+    padding-bottom: calc(100% * #{$image-ratio});
+    max-width: 500px;
+  }
 
   @include Breakpoint-desktopOnly {
-    transform: none;
+    margin-top: 0;
   }
+}
+
+.Moving-portoImage,
+.Moving-lisbonImage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: $Moving-z-index-background;
 }
 
 .Moving-portoImage {
   $pre: linear-gradient(to top, $Moving-gradient-start-color, $Moving-gradient-end-color);
-  @include responsive-background-image("../../images/moving/porto", $pre: $pre);
+  @include responsive-background-image("../../images/moving/porto", $pre: $pre, $size: cover);
 
   @include Breakpoint-desktopOnly {
     $pre: linear-gradient(to left, $Moving-gradient-start-color, $Moving-gradient-end-color);
-    @include responsive-background-image("../../images/moving/porto", $pre: $pre);
+    @include responsive-background-image("../../images/moving/porto", $pre: $pre, $size: cover);
   }
 }
 
 .Moving-lisbonImage {
   $pre: linear-gradient(to top, $Moving-gradient-start-color, $Moving-gradient-end-color);
-  @include responsive-background-image("../../images/moving/lisbon", $pre: $pre);
+  @include responsive-background-image("../../images/moving/lisbon", $pre: $pre, $size: cover);
 
   @include Breakpoint-desktopOnly {
     $pre: linear-gradient(to right, $Moving-gradient-start-color, $Moving-gradient-end-color);
-    @include responsive-background-image("../../images/moving/lisbon", $pre: $pre);
+    @include responsive-background-image("../../images/moving/lisbon", $pre: $pre, $size: cover);
   }
 }
 
@@ -90,13 +107,14 @@ $Moving-gradient-start-color: rgba(13, 29, 97, 0.4);
 
 .Moving-description {
   position: relative;
-
-  padding-left: $Spacing-xSmall;
-
   z-index: $Moving-z-index-foreground;
+}
 
+.Moving-descriptionNumberedBlock {
   @include Breakpoint-desktopOnly {
-    padding: 0;
+    position: relative;
+    top: 0;
+    left: -$Spacing-xSmall;
   }
 }
 

--- a/css/Components/NumberedBlock.scss
+++ b/css/Components/NumberedBlock.scss
@@ -1,4 +1,5 @@
 @import "../Theme/Spacing";
+@import "../Theme/Global";
 
 .NumberedBlock {
   position: relative;
@@ -6,9 +7,14 @@
 
 .NumberedBlock-number {
   position: absolute;
+  top: 0;
+  left: 0;
 
-  top: 50%;
-  left: -$Spacing-xSmall;
+  font-family: $Global-font-family-serif;
+  font-size: 18px;
+  line-height: 26px;
+}
 
-  transform: translateY(-50%);
+.NumberedBlock-block {
+  padding-left: $Spacing-xSmall;
 }

--- a/css/Theme/Breakpoint.scss
+++ b/css/Theme/Breakpoint.scss
@@ -2,7 +2,7 @@ $Breakpoint-mobile: 650px;
 $Breakpoint-desktop: 1024px;
 
 @mixin Breakpoint-mobileOnly {
-  @media screen and (max-width: $Breakpoint-mobile) {
+  @media screen and (max-width: #{$Breakpoint-mobile - 1}) {
     @content
   };
 };
@@ -15,6 +15,12 @@ $Breakpoint-desktop: 1024px;
 
 @mixin Breakpoint-tabletAndAbove {
   @media screen and (min-width: $Breakpoint-mobile) {
+    @content
+  };
+};
+
+@mixin Breakpoint-tabletAndBelow {
+  @media screen and (max-width: #{$Breakpoint-desktop - 1}) {
     @content
   };
 };


### PR DESCRIPTION
Why:

*
https://trello.com/c/m7GWPT7k/134-photos-on-mobile-with-a-weird-rectangle-on-the-bottom

This change addresses the need by:

* Replacing fixed height for the *padding hack* in order to achieve a 
redimension of the image according to the width available
* Changing the image's `background-size` to `cover` as it's more approriate to
the desired effect
* Restyling `.NumberedBlock` to have the proper font styles and not to 
position itself absolutely, moving that responsibility to its parent -
`.Moving`