### PR TITLE
Fix schedule table column width on mobile layout

### DIFF
--- a/css/Components/Event.scss
+++ b/css/Components/Event.scss
@@ -9,10 +9,14 @@
   &-heading,
   &-subHeading {
     font-family: $Global-font-family-sans;
-    font-size: 18px;
+    font-size: 13px;
     line-height: 1.5;
     color: $Color-white;
     font-weight: bold;
+
+    @media screen and (min-width: 355px) {
+      font-size: 18px;
+    }
 
     @include Breakpoint-desktopOnly {
       font-size: 26px;

--- a/css/Components/ScheduleTable.scss
+++ b/css/Components/ScheduleTable.scss
@@ -33,7 +33,7 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     vertical-align: top;
   };
 
-  &-header {
+  .ScheduleTable-header {
     margin-bottom: $Spacing-xxSmall;
 
     text-align: center;
@@ -48,7 +48,7 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     };
   }
 
-  &:first-child &-header {
+  &:first-child .ScheduleTable-header {
     margin-left: $ScheduleTable-time-column-width;
 
     @include Breakpoint-tabletAndAbove {
@@ -56,7 +56,7 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     };
   }
 
-  &-row {
+  .ScheduleTable-row {
     display: flex;
     flex-wrap: nowrap;
 
@@ -69,7 +69,7 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     };
   }
 
-  &-row + &-row {
+  .ScheduleTable-row + .ScheduleTable-row {
     margin-top: $Spacing-xxSmall;
 
     @include Breakpoint-tabletAndAbove {
@@ -77,7 +77,7 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     }
   }
 
-  &-rowGutter {
+  .ScheduleTable-rowGutter {
     height: $Spacing-xxSmall;
 
     margin-left: $ScheduleTable-time-column-width;
@@ -91,7 +91,7 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     };
   }
 
-  &-columnHeader {
+  .ScheduleTable-columnHeader {
     padding: $Spacing-xxSmall;
 
     font-size: 13px;
@@ -108,20 +108,29 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     };
   }
 
-  &-column {
+  .ScheduleTable-column {
     flex: 1;
+
+    min-width: calc(50% - #{$Spacing-xSmall} - #{$ScheduleTable-time-column-width});
 
     background-color: rgba($Color-white, 0.1);
 
     vertical-align: top;
+
+    @include Breakpoint-tabletAndAbove {
+      min-width: calc(25% - #{$Spacing-base} - #{$ScheduleTable-time-column-width-desktop});
+    };
   }
 
-  &-column.pushLeft {
+  .ScheduleTable-column.pushLeft {
+    flex: $ScheduleTable-time-column-width;
+
     position: absolute;
 
     left: 0;
     bottom: 0;
     width: $ScheduleTable-time-column-width;
+    min-width: $ScheduleTable-time-column-width;
 
     transform: translateX(-$ScheduleTable-time-column-width);
 
@@ -129,12 +138,13 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
 
     @include Breakpoint-tabletAndAbove {
       width: $ScheduleTable-time-column-width-desktop;
+      min-width: $ScheduleTable-time-column-width-desktop;
 
       transform: translateX(-$ScheduleTable-time-column-width-desktop);
     };
   }
 
-  &-columnGutter {
+  .ScheduleTable-columnGutter {
     align-self: flex-end;
 
     width: $Spacing-xxSmall;
@@ -144,7 +154,7 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     };
   }
 
-  &-cell {
+  .ScheduleTable-cell {
     position: relative;
 
     height: 100%;
@@ -158,7 +168,7 @@ $ScheduleTable-durations-in-minutes: 15 30 45 60 75 120 180 240;
     };
   }
 
-  &-cell.filler {
+  .ScheduleTable-cell.filler {
     display: none;
 
     @include Breakpoint-tabletAndAbove {


### PR DESCRIPTION
Why:

* Currently the table has one column bigger than the other on mobile;

This changes addresses the need by:

* Adjusting the `min-width` of the columns correctly;

Before:
![www mirrorconf com-schedule- iphone 5](https://user-images.githubusercontent.com/4236592/31341643-0d286f54-ad02-11e7-95e1-0c51c7a5c382.png)

After:
![localhost-8000-schedule- iphone 5](https://user-images.githubusercontent.com/4236592/31341638-068c45da-ad02-11e7-95e4-accd5cae8426.png)


