### PR TITLE
Fixes tabs' displacement above 1024px

### DIFF
--- a/css/Components/Tabs.scss
+++ b/css/Components/Tabs.scss
@@ -13,10 +13,6 @@ $Tabs-link-height: 4px;
   height: 0;
 
   transform: translateY(-2px);
-
-  @include Breakpoint-desktopOnly {
-    transform: translateY(-18px);
-  };
 }
 
 .Tabs-link {

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -41,7 +41,9 @@ const Schedule = () => (
     </Section>
     <div className="Schedule-body">
       <div className="Grid Grid--1offset">
-        <Tabs tabs={tabs} activeTab={tabs[1]} />
+        <div className="Grid-9column md-11">
+          <Tabs tabs={tabs} activeTab={tabs[1]} />
+        </div>
       </div>
     </div>
     <div className="Schedule-footer">


### PR DESCRIPTION
## Before

<img width="1439" alt="screen shot 2017-10-16 at 3 31 07 pm" src="https://user-images.githubusercontent.com/448574/31617428-114fe7da-b287-11e7-99d5-f37c476d9517.png">

## After

<img width="1440" alt="screen shot 2017-10-16 at 3 31 42 pm" src="https://user-images.githubusercontent.com/448574/31617466-2f01ef9e-b287-11e7-9696-c644609bfa79.png">
